### PR TITLE
Optional index for Shadowbox.display

### DIFF
--- a/examples/gallery.html
+++ b/examples/gallery.html
@@ -1,0 +1,45 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
+    "http://www.w3.org/TR/html4/strict.dtd">
+
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>Gallery</title>
+		<link rel="stylesheet" type="text/css" href="files/style.css">
+		<link rel="stylesheet" type="text/css" href="build/shadowbox.css">
+		<script type="text/javascript" src="build/shadowbox.js"></script>
+		<script type="text/javascript">
+			Shadowbox.init();
+			var images = [{
+				content: 'files/hongkong-1.jpg',
+				player: 'img',
+				title: 'First Image'
+			}, {
+				content: 'files/hongkong-2.jpg',
+				player: 'img',
+				title: 'Second Image'
+			}, {
+				content: 'files/hongkong-3.jpg',
+				player: 'img',
+				title: 'Third Image'
+			}];
+			function openShadowbox(index) {
+				Shadowbox.open(images, index);
+			}
+		</script>
+	</head>
+	<body>
+		<p>
+			This example shows how to use Shadowbox.open and start at a certain position in the gallery.
+		</p>
+	    <p>
+	    	<img src="files/hongkong.jpg" width="600" height="82" alt="Hong Kong" usemap="#hongkong">
+		    <map id="hongkong" name="hongkong">
+		        <area shape="rect" coords="43,27,135,77" href="#" onclick="openShadowbox(0)" alt="">
+		        <area shape="rect" coords="191,11,286,74" href="#" onclick="openShadowbox(1)" alt="">
+		        <area shape="rect" coords="419,2,502,81" href="#" onclick="openShadowbox(2)" alt="">
+		    </map>
+	    </p>
+	    <p id="foot">This file is part of <a href="http://shadowbox-js.com/">Shadowbox.js</a>.</p>
+	</body>
+</html>

--- a/source/adapters/jquery.js
+++ b/source/adapters/jquery.js
@@ -98,6 +98,11 @@ jQuery.fn.shadowbox = function(options) {
         var cls = this.className || '';
         opts.width  = parseInt((cls.match(/w:(\d+)/)||[])[1]) || opts.width;
         opts.height = parseInt((cls.match(/h:(\d+)/)||[])[1]) || opts.height;
+		// title
+		var title = el.attr('title');
+		if (title) {
+			opts.title = title;
+		}
         Shadowbox.setup(el, opts);
     });
 }

--- a/source/core.js
+++ b/source/core.js
@@ -444,20 +444,24 @@ S.init = function(options, callback) {
  * - A custom object similar to one produced by Shadowbox.makeObject
  * - An array of any of the above
  *
+ * If an array is given, the second parameter specifies the index of the first
+ * element, that should be displayed.
+ *
  * Note: When a single link object is given, Shadowbox will automatically search
  * for other cached link objects that have been set up in the same gallery and
  * display them all together.
  *
  * @param   {mixed}     obj
+ * @param	{Integer}	index (optional)
  * @public
  */
-S.open = function(obj) {
+S.open = function(obj, index) {
     if (open)
         return;
-
+	
     var gc = S.makeGallery(obj);
     S.gallery = gc[0];
-    S.current = gc[1];
+    S.current = index || gc[1];
 
     obj = S.getCurrent();
 


### PR DESCRIPTION
When calling Shadowbox.display with an array of objects, one can now pass a second argument: the index of the element, that should be displayed first.
I also added an example, that shows, in what kind of scenario this can be useful.
