### PR TITLE
Fix for TypeError (missing method: String#contains)

### DIFF
--- a/source/plugins.js
+++ b/source/plugins.js
@@ -15,7 +15,6 @@ if (navigator.plugins && navigator.plugins.length) {
     each(navigator.plugins, function(i, p) {
         names.push(p.name);
     });
-    names = names.join(',');
 
     S.plugins = {
         fla:    names.contains('Shockwave Flash'),


### PR DESCRIPTION
Hi Michael,

I used your "rake build" task to build an unminified version of Shadowbox to help us track down a bug in an upcoming site of ours.  In the process, I inadvertently used HEAD instead of v3.0.3, and ended up finding and fixing the following bug:

```
Uncaught TypeError: Object Shockwave Flash,Shockwave Flash,QuickTime Plug-in 7.6.6,Java Plug-In 2 for NPAPI Browsers,Chrome PDF Viewer,iPhotoPhotocast,Default Plug-in has no method 'contains'
```

Just a simple Array to String conversion problem.  I hope this helps!

Thanks for maintaining Shadowbox!

Best wishes,

Ben
## 

Benjamin Oakes
Software Developer
Hedgeye Risk Management
http://www.hedgeye.com/
GitHub: @benjaminoakes
Twitter: @benjaminoakes
