### PR TITLE
fixed closing shadowbox on overlay click

### DIFF
--- a/source/skin.js
+++ b/source/skin.js
@@ -619,7 +619,7 @@ K.onOpen = function(obj, callback) {
         overlay.style.backgroundColor = S.options.overlayColor;
         S.setOpacity(overlay, 0);
 
-        if (!S.options.modal)
+        if (S.options.modal)
             addEvent(overlay, "click", S.close);
 
         overlayOn = true;


### PR DESCRIPTION
'modal = true' is not closing the shadowbox on overlay click as described in:

```
/**
 * True to trigger Shadowbox.close when the overlay is clicked.
 *
 * @type    {Boolean}
 */
```
