### PR TITLE
Fixed bug that get the correct keycode value in IE6-8

### DIFF
--- a/source/shadowbox.js
+++ b/source/shadowbox.js
@@ -714,7 +714,9 @@
     if (eventHasModifierKey(event))
       return;
 
-    switch (event.keyCode) {
+    var keycode = event.which || event.keyCode;
+
+    switch (keycode) {
     case KEY_ESCAPE:
     case KEY_Q:
     case KEY_X:
@@ -1294,7 +1296,6 @@
     event.preventDefault = preventDefault;
     event.stopPropagation = stopPropagation;
     event.target = event.srcElement;
-    event.keyCode = event.which || event.keyCode;
     return event;
   }
 

--- a/source/shadowbox.js
+++ b/source/shadowbox.js
@@ -1294,7 +1294,7 @@
     event.preventDefault = preventDefault;
     event.stopPropagation = stopPropagation;
     event.target = event.srcElement;
-    event.keyCode = event.which;
+    event.keyCode = event.which || event.keyCode;
     return event;
   }
 


### PR DESCRIPTION
Fixed bug that get the correct keycode value in IE6-8
Fixed bug that preventing “SCRIPT5: Access is denied” error in IE
