### PR TITLE
Add ability to set a parent element for the player

### DIFF
--- a/source/shadowbox.js
+++ b/source/shadowbox.js
@@ -80,6 +80,9 @@
     // Opacity for the overlay.
     overlayOpacity: 0.5,
 
+    // Parent element for the overlay. This should be a DOM element.
+    parentElement: document.body,
+
     // The index in the current gallery at which to start when first opening.
     startIndex: 0
 
@@ -115,7 +118,7 @@
   /**
    * Appends Shadowbox to the DOM and initializes DOM references.
    */
-  function initialize() {
+  function initialize(parentElement) {
     if (containerElement)
       return; // Don't initialize twice!
 
@@ -145,7 +148,7 @@
     var previousElement = makeDom("div", { id: "sb-prev" });
 
     // Append #shadowbox to the DOM.
-    makeDom(document.body, [
+    makeDom(parentElement, [
       makeDom(containerElement, [
         overlayElement,
         makeDom(wrapperElement, [
@@ -224,7 +227,7 @@
     // Display the first item in the gallery, if there's anything left.
     if (currentGallery.length > 0) {
       if (currentIndex == -1) {
-        initialize();
+        initialize(currentOptions.parentElement);
 
         if (isFunction(currentOptions.onOpen))
           currentOptions.onOpen();


### PR DESCRIPTION
I'm building a site and want a lightweight gallery -- this seemed to be a perfect easily extensible tool to use. The only thing I needed was the ability to specify where in the DOM I wanted to put the thing.

This option can be set just like the rest of the options, and requires a DOM element, e.g.

``` javascript
shadowbox.options = {
  parentElement: document.getElementById( 'gallery' )
};
```
